### PR TITLE
properly link against librt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ INCLUDE_DIRECTORIES(
 )
 
 # ######### Build defaults ##########
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2 -lrt")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -O2")
 
 # ########## ttylog executable ##########
 # Sources:
@@ -43,6 +43,11 @@ INCLUDE(CPack)
 
 # actual target:
 ADD_EXECUTABLE(ttylog ${ttylog_executable_SRCS})
+
+# link against librt:
+if(UNIX AND NOT APPLE)
+    target_link_libraries(ttylog rt)
+endif()
 
 # add install targets:
 INSTALL(TARGETS ttylog DESTINATION sbin)


### PR DESCRIPTION
The linking against librt should be done by CMake using target_link_libraries to ensure a proper linking order (which avoids issues in places like Ubuntu, which use ld --as-needed and require a specific linking order of libraries after objects that need them).

This also ensures that the linking against librt only happens on Unix-based systems and not OS X, which doesn't have that library.