### PR TITLE
timestamp option

### DIFF
--- a/ttylog.c
+++ b/ttylog.c
@@ -48,7 +48,7 @@ main (int argc, char *argv[])
 {
   FILE *logfile;
   fd_set rfds;
-  int retval, i, j, baud = -1;
+  int retval, i, j, baud, stamp = -1;
   timer_t timerid;
   struct sigevent sevp;
   sevp.sigev_notify = SIGEV_SIGNAL;
@@ -56,6 +56,9 @@ main (int argc, char *argv[])
   int fd;
   char line[1024], modem_device[512];
   struct termios oldtio, newtio;
+  time_t rawtime;
+  struct tm *timeinfo;
+  char *timestr;
 
   modem_device[0] = 0;
 
@@ -74,6 +77,7 @@ main (int argc, char *argv[])
           printf ("Usage:  ttylog [-b|--baud] [-d|--device] [-f|--flush] [-t|--timeout] > /path/to/logfile\n");
           printf (" -h, --help	This help\n -v, --version	Version number\n -b, --baud	Baud rate\n");
           printf (" -d, --device	Serial device (eg. /dev/ttyS1)\n -f, --flush	Flush output\n");
+          printf (" -s, --stamp\tPrefix each line with datestamp\n");
           printf (" -t, --timeout  How long to run, in seconds.\n");
           printf ("ttylog home page: <http://ttylog.sourceforge.net/>\n\n");
           exit (0);
@@ -95,6 +99,11 @@ main (int argc, char *argv[])
       if (!strcmp (argv[i], "-f") || !strcmp (argv[i], "--flush"))
         {
           flush = 1;
+        }
+
+      if (!strcmp (argv[i], "-s") || !strcmp (argv[i], "--stamp"))
+        {
+          stamp = 1;
         }
 
       if (!strcmp (argv[i], "-b") || !strcmp (argv[i], "--baud"))
@@ -202,7 +211,17 @@ main (int argc, char *argv[])
       if (retval)
         {
           fgets (line, 1024, logfile);
-          fputs (line, stdout);
+          if (stamp)
+            {
+              time(&rawtime);
+              timeinfo = localtime(&rawtime);
+              timestr = asctime(timeinfo);
+              timestr[strlen(timestr) - 1] = 0;
+              printf ("[%s] %s", timestr, line);
+            } else {
+              fputs (line, stdout);
+            }
+
           if (flush) { fflush(stdout); }
         }
     }


### PR DESCRIPTION
Added a -s (--stamp) option to prefix every output line with a timestamp.

This is useful when e.g. logging sensor output from a sensor with no clock.
