### PR TITLE
Bugfix: exit on unreadable file descriptor

### DIFF
--- a/ttylog.c
+++ b/ttylog.c
@@ -209,9 +209,12 @@ main (int argc, char *argv[])
       FD_ZERO (&rfds);
       FD_SET (fd, &rfds);
       retval = select (fd + 1, &rfds, NULL, NULL, NULL);
-      if (retval)
+      if (retval > 0)
         {
-          fgets (line, 1024, logfile);
+          if (!fgets (line, 1024, logfile))
+            {
+              if (ferror (logfile)) { break; }
+            }
           if (stamp)
             {
               time(&rawtime);
@@ -225,6 +228,7 @@ main (int argc, char *argv[])
 
           if (flush) { fflush(stdout); }
         }
+      else if (retval < 0) { break; }
     }
 
   fclose (logfile);


### PR DESCRIPTION
When the tty's file descriptor became unreadable, exit instead of
entering an infinite loop.
This can happen when a USB device is removed.