### PR TITLE
Bugfix: make the timestamp optional

### DIFF
--- a/ttylog.c
+++ b/ttylog.c
@@ -49,7 +49,8 @@ main (int argc, char *argv[])
 {
   FILE *logfile;
   fd_set rfds;
-  int retval, i, j, baud, stamp = -1;
+  int retval, i, j, baud = -1;
+  int stamp = 0;
   timer_t timerid;
   struct sigevent sevp;
   sevp.sigev_notify = SIGEV_SIGNAL;


### PR DESCRIPTION
The "stamp" variable was initialized to "-1", which is evaluated as
true in the if statement.
This change makes the timestamp option disabled by default.