### PR TITLE
macOS: remove timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you are not using the timeout option, you can stop it running by pressing a
 ctrl-c when it's going to the screen or doing 'kill -HUP nnnn' if running it in
 the background.
 
+The timeout option is not available on macOS.
+
 Web sites
 -----------
 
@@ -41,8 +43,3 @@ https://sourceforge.net/p/ttylog/bugs/
 https://sourceforge.net/p/ttylog/patches/
 https://sourceforge.net/p/ttylog/feature-requests/
 https://github.com/rocasa/ttylog/issues
-
-
-
-
-

--- a/ttylog.8
+++ b/ttylog.8
@@ -33,7 +33,7 @@ The serial device. For example /dev/ttyS1
 Output buffers are flushed after every write.
 .TP
 .B -t --timeout
-How long to run ttylog, in seconds.
+How long to run ttylog, in seconds. NOTE: this option is not available on macOS.
 .SH AUTHOR
 This manual page was originally written by Tibor Koleszar <t.koleszar@somogy.hu>,
 for the Debian GNU/Linux system.  Modifications and updates written by

--- a/ttylog.c
+++ b/ttylog.c
@@ -52,7 +52,9 @@ main (int argc, char *argv[])
   fd_set rfds;
   int retval, i, j, baud = -1;
   int stamp = 0;
+#ifndef __APPLE__
   timer_t timerid;
+#endif
   struct sigevent sevp;
   sevp.sigev_notify = SIGEV_SIGNAL;
   sevp.sigev_signo = SIGINT;
@@ -77,11 +79,17 @@ main (int argc, char *argv[])
       if (!strcmp (argv[i], "-h") || !strcmp (argv[i], "--help"))
         {
           printf ("ttylog version %s\n", TTYLOG_VERSION);
+#ifndef __APPLE__
           printf ("Usage:  ttylog [-b|--baud] [-d|--device] [-f|--flush] [-s|--stamp] [-t|--timeout] > /path/to/logfile\n");
+#else
+          printf ("Usage:  ttylog [-b|--baud] [-d|--device] [-f|--flush] [-s|--stamp] > /path/to/logfile\n");
+#endif
           printf (" -h, --help	This help\n -v, --version	Version number\n -b, --baud	Baud rate\n");
           printf (" -d, --device	Serial device (eg. /dev/ttyS1)\n -f, --flush	Flush output\n");
           printf (" -s, --stamp\tPrefix each line with datestamp\n");
+#ifndef __APPLE__
           printf (" -t, --timeout  How long to run, in seconds.\n");
+#endif
           printf ("ttylog home page: <http://ttylog.sourceforge.net/>\n\n");
           exit (0);
         }
@@ -141,6 +149,10 @@ main (int argc, char *argv[])
 
     if (!strcmp (argv[i], "-t") || !strcmp (argv[i], "--timeout"))
       {
+#ifdef __APPLE__
+        printf ("ERROR: --timeout / -t option not available on macOS\n\n");
+        exit (1);
+#else
         if (argv[i + 1] == NULL)
           {
             printf ("%s: invalid time span %s\n", argv[0], argv[i + 1]);
@@ -167,6 +179,7 @@ main (int argc, char *argv[])
             printf ("%s: unable to set timer time: %s\n", argv[0], strerror(errno));
             exit (0);
           }
+#endif
       }
     }
 


### PR DESCRIPTION
Previously, this software would not build on macOS because timer_t is
not available.

Now, when --timeout or -t option is provided on the command line,
on macOS, an error message is displayed that this option is not
available and the program exits.

See https://github.com/rocasa/ttylog/issues/6